### PR TITLE
docs: link vignettes to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ rmarkdown::render("vignette/malaria_hb_vignette.Rmd")
 ```
 
 Rendered HTML versions (`*.html`) are provided in the `vignette/` directory for quick browsing.
+They are also available online via GitHub Pages:
+
+- [data_generation.html](https://patrickgtwalker.github.io/Anaemia_malaria_fitting_open/vignette/data_generation.html)
+- [malaria_hb_vignette.html](https://patrickgtwalker.github.io/Anaemia_malaria_fitting_open/vignette/malaria_hb_vignette.html)
 
 ## Example data
 


### PR DESCRIPTION
## Summary
- add GitHub Pages URLs for HTML vignettes in README

## Testing
- `Rscript -e 'rmarkdown::render("vignette/data_generation.Rmd")'` *(fails: there is no package called 'rmarkdown')*

------
https://chatgpt.com/codex/tasks/task_e_686f87e2ad6883208e2ca29713daa461